### PR TITLE
[Fix] #118- GetAlarmResponse 파일 제거

### DIFF
--- a/Peekabook/Peekabook.xcodeproj/project.pbxproj
+++ b/Peekabook/Peekabook.xcodeproj/project.pbxproj
@@ -164,7 +164,6 @@
 		8E4083DD2970114C00B53339 /* EditPickRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPickRequest.swift; sourceTree = "<group>"; };
 		8E4083DF2970122B00B53339 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; name = .gitkeep; path = Peekabook/Network/DTO/Alarm/.gitkeep; sourceTree = SOURCE_ROOT; };
 		8E4083E82970BFF600B53339 /* GetAlarmResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetAlarmResponse.swift; sourceTree = "<group>"; };
-		8E4083EA2970C01900B53339 /* GetAlarmResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GetAlarmResponse.swift; path = Peekabook/Network/DTO/Alarm/GetAlarmResponse.swift; sourceTree = "<group>"; };
 		8E5A309E295DAE6D00285A15 /* Peekabook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Peekabook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E5A30A1295DAE6D00285A15 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8E5A30A3295DAE6D00285A15 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -607,7 +606,6 @@
 		8E5A3095295DAE6D00285A15 = {
 			isa = PBXGroup;
 			children = (
-				8E4083EA2970C01900B53339 /* GetAlarmResponse.swift */,
 				8E10BA4D2960026600BCF58B /* .swiftlint.yml */,
 				8E5A30A0295DAE6D00285A15 /* Peekabook */,
 				8E5A309F295DAE6D00285A15 /* Products */,


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#118

👷 **작업한 내용**
- 프로젝트 경로 상단에 중복된 타겟 설정 해제된 GetAlarmResponse 파일을 삭제했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 📟 관련 이슈
- Resolved: #118
- Closed: #116
