### PR TITLE
[Chore] #108- 유저, 친구 타입에 따른 레이아웃 변경 코드 추가

### DIFF
--- a/Peekabook/Peekabook/Presentation/BookDetail/VC/BookDetailVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookDetail/VC/BookDetailVC.swift
@@ -44,20 +44,17 @@ final class BookDetailVC: UIViewController {
     }
     
     private let bookImageView = UIImageView().then {
-        $0.image = ImageLiterals.Sample.book1
         $0.layer.masksToBounds = false
         $0.contentMode = .scaleToFill
         $0.layer.applyShadow(color: .black, alpha: 0.25, x: 0, y: 4, blur: 4, spread: 0)
     }
     
     private var bookNameLabel = UILabel().then {
-        $0.text = "아무튼, 여름"
         $0.font = .h3
         $0.textColor = .peekaRed
     }
     
     private var bookAuthorLabel = UILabel().then {
-        $0.text = "김신회"
         $0.font = .h2
         $0.textColor = .peekaRed
     }
@@ -69,7 +66,6 @@ final class BookDetailVC: UIViewController {
     }
     
     private let commentTextView = UITextView().then {
-        $0.text = I18N.BookDetail.commentSample
         $0.font = .h2
         $0.textColor = .peekaRed
         $0.backgroundColor = .clear
@@ -84,7 +80,6 @@ final class BookDetailVC: UIViewController {
     }
     
     private lazy var memoTextView = UITextView().then {
-        $0.text = I18N.BookDetail.memoSample
         $0.font = .h2
         $0.textColor = .peekaRed
         $0.backgroundColor = .clear

--- a/Peekabook/Peekabook/Presentation/BookDetail/VC/BookDetailVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookDetail/VC/BookDetailVC.swift
@@ -248,7 +248,21 @@ extension BookDetailVC {
 // MARK: - Methods
 
 extension BookDetailVC {
-    func getBookDetail(bookId: Int) {
+    func changeUserViewLayout() {
+        self.editButton.isHidden = false
+        self.deleteButton.isHidden = false
+    }
+    
+    func changeFriendViewLayout() {
+        self.editButton.isHidden = true
+        self.deleteButton.isHidden = true
+    }
+}
+
+// MARK: - Network
+
+extension BookDetailVC {
+    private func getBookDetail(bookId: Int) {
         BookShelfAPI.shared.getBookDetail(bookId: bookId) { response in
             guard let serverWatchBookDetail = response?.data else { return }
             self.bookImageView.kf.setImage(with: URL(string: serverWatchBookDetail.book.bookImage))

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -501,6 +501,12 @@ extension BookShelfVC: UICollectionViewDelegate, UICollectionViewDataSource {
         
         if collectionView == pickCollectionView {
             let bookDetailVC = BookDetailVC()
+            switch bookShelfType {
+            case .user:
+                bookDetailVC.changeUserViewLayout()
+            case .friend:
+                bookDetailVC.changeFriendViewLayout()
+            }
             bookDetailVC.hidesBottomBarWhenPushed = true
             bookDetailVC.selectedBookIndex = picks[indexPath.row].book.id
             navigationController?.pushViewController(bookDetailVC, animated: true)


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#108

👷 **작업한 내용**
- 유저, 친구 타입에 따른 레이아웃 변경 코드 추가

## 🚨 참고 사항
- 서버가 이상해서 친구책 상세보기는 더미데이터로 뷰가 구현됩니다. 위에 네비바 부분만 봐주세용

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "![Simulator Screen Recording - iPhone 11 Pro - 2023-01-13 at 07 59 46](https://user-images.githubusercontent.com/80062632/212199499-812995a5-018f-4818-bd00-7059373ba286.gif)" width ="250">|

## 📟 관련 이슈
- Resolved: #108
