### PR TITLE
[Feat] #231 - 로그인로직수정

### DIFF
--- a/Peekabook/Peekabook.xcodeproj/project.pbxproj
+++ b/Peekabook/Peekabook.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		143DBFD52971ECE20056C609 /* MyPageTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143DBFD42971ECE20056C609 /* MyPageTVC.swift */; };
 		143DBFD72971FA980056C609 /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143DBFD62971FA980056C609 /* MyPageHeaderView.swift */; };
 		143FC665296EBA2B0034C7B9 /* GetRecommendResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143FC664296EBA2B0034C7B9 /* GetRecommendResponse.swift */; };
+		145DC3142A04ED8D00D2FB50 /* GetUpdatedTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145DC3132A04ED8D00D2FB50 /* GetUpdatedTokenResponse.swift */; };
 		1481CDD9296D227500F2B207 /* SearchUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1481CDD8296D227500F2B207 /* SearchUserResponse.swift */; };
 		148C2E45296F64D200E04662 /* DeletePopUpVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148C2E44296F64D200E04662 /* DeletePopUpVC.swift */; };
 		14B354482968897C00998925 /* NotificationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B354472968897C00998925 /* NotificationModel.swift */; };
@@ -171,6 +172,7 @@
 		143DBFD42971ECE20056C609 /* MyPageTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTVC.swift; sourceTree = "<group>"; };
 		143DBFD62971FA980056C609 /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
 		143FC664296EBA2B0034C7B9 /* GetRecommendResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRecommendResponse.swift; sourceTree = "<group>"; };
+		145DC3132A04ED8D00D2FB50 /* GetUpdatedTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUpdatedTokenResponse.swift; sourceTree = "<group>"; };
 		1481CDD8296D227500F2B207 /* SearchUserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUserResponse.swift; sourceTree = "<group>"; };
 		148C2E44296F64D200E04662 /* DeletePopUpVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePopUpVC.swift; sourceTree = "<group>"; };
 		14B354472968897C00998925 /* NotificationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModel.swift; sourceTree = "<group>"; };
@@ -979,6 +981,7 @@
 				98EAD31C29D9CEB8000181AF /* SocialLoginRequest.swift */,
 				9833296129E04E8C00D9DE5A /* SocialLoginResponse.swift */,
 				9833295F29E03ECF00D9DE5A /* SignUpRequest.swift */,
+				145DC3132A04ED8D00D2FB50 /* GetUpdatedTokenResponse.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -1228,6 +1231,7 @@
 				8E81F40329608B00001815B4 /* MyNotificationVC.swift in Sources */,
 				8E81F3E2296082FB001815B4 /* UIViewController+.swift in Sources */,
 				8E18506A2969BA9F0062E92A /* GeneralResponse.swift in Sources */,
+				145DC3142A04ED8D00D2FB50 /* GetUpdatedTokenResponse.swift in Sources */,
 				14C84E3729D439450086F8DF /* SignUpVC.swift in Sources */,
 				8E81F3DC296080D4001815B4 /* setClearButton.swift in Sources */,
 				8E2855C5296DEEB0005F0E1D /* FriendBookShelfResponse.swift in Sources */,

--- a/Peekabook/Peekabook/Application/AppDelegate.swift
+++ b/Peekabook/Peekabook/Application/AppDelegate.swift
@@ -35,18 +35,34 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let defaults = UserDefaults.standard
         let accessToken = Config.accessToken
         let userManager = UserManager.shared
-        let isLoggedIn = accessToken != "" && !userManager.isLoggedIn
         
-        if isLoggedIn {
+        print("✅✅✅!! 유저디폴트로 바꾼 경우 !!!✅✅✅")
+        print(defaults.bool(forKey: "signedUpComplete"))
+        if let accessToken = defaults.string(forKey: "accessToken") {
+            print(accessToken)
+        }
+        if let refreshToken = defaults.string(forKey: "refreshToken") {
+            print(refreshToken)
+        }
+//        print(defaults.string(forKey: "accessToken"))
+//        print(defaults.string(forKey: "refreshToken"))
+        print("--------------------    AppDelegate    ------------------------")
+        
+        print("✅✅✅!! Config로 바꾼 경우 !!!✅✅✅")
+        
+        print(Config.accessToken)
+        print(Config.isSignedUp)
+        
+        print("--------------------    AppDelegate    ------------------------")
+        
+        if defaults.bool(forKey: "signedUpComplete") {
             let rootViewController = TabBarController()
             window?.rootViewController = rootViewController
             Config.accessToken = accessToken
-            UserManager.shared.isLoggedIn = true
             window?.makeKeyAndVisible()
         } else {
             let loginViewController = OnboardingVC()
             window?.rootViewController = loginViewController
-            UserManager.shared.isLoggedIn = false
             window?.makeKeyAndVisible()
         }
         

--- a/Peekabook/Peekabook/Application/AppDelegate.swift
+++ b/Peekabook/Peekabook/Application/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let userManager = UserManager.shared
         
         print("✅✅✅!! 유저디폴트로 바꾼 경우 !!!✅✅✅")
-        print(defaults.bool(forKey: "signedUpComplete"))
+        print(defaults.bool(forKey: "isSignedUpComplete"))
         if let accessToken = defaults.string(forKey: "accessToken") {
             print(accessToken)
         }
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         print("--------------------    AppDelegate    ------------------------")
         
-        if defaults.bool(forKey: "signedUpComplete") {
+        if defaults.bool(forKey: "isSignedUpComplete") {
             let rootViewController = TabBarController()
             window?.rootViewController = rootViewController
             Config.accessToken = accessToken

--- a/Peekabook/Peekabook/Application/SceneDelegate.swift
+++ b/Peekabook/Peekabook/Application/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let userDefaults = UserDefaults.standard
         
-        let isLoggedIn: Bool = userDefaults.bool(forKey: "signedUpComplete")
+        let isLoggedIn: Bool = userDefaults.bool(forKey: "isSignedUpComplete")
         print("✅✅✅!! 유저디폴트로 바꾼 경우 !!!✅✅✅")
         print(isLoggedIn)
         print("--------------------    SceneDelegate    ------------------------")

--- a/Peekabook/Peekabook/Application/SceneDelegate.swift
+++ b/Peekabook/Peekabook/Application/SceneDelegate.swift
@@ -17,7 +17,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         
-        var isLoggedIn: Bool = UserManager.shared.isLoggedIn
+        let userDefaults = UserDefaults.standard
+        
+        let isLoggedIn: Bool = userDefaults.bool(forKey: "signedUpComplete")
+        print("✅✅✅!! 유저디폴트로 바꾼 경우 !!!✅✅✅")
+        print(isLoggedIn)
+        print("--------------------    SceneDelegate    ------------------------")
         if isLoggedIn {
             let rootViewController = TabBarController()
             window?.rootViewController = rootViewController

--- a/Peekabook/Peekabook/Network/API/AuthAPI.swift
+++ b/Peekabook/Peekabook/Network/API/AuthAPI.swift
@@ -17,6 +17,7 @@ final class AuthAPI {
     private init() { }
     
     private(set) var socialLoginData: GeneralResponse<SocialLoginResponse>?
+    private(set) var getUpdatedTokenData: GeneralResponse<GetUpdatedTokenResponse>?
     
     // 1. 소셜 로그인 API
     
@@ -35,4 +36,23 @@ final class AuthAPI {
             }
         }
     }
+    
+    // 2. 토큰 재발급 API
+    
+    func getUpdatedTokenAPI(completion: @escaping (GeneralResponse<GetUpdatedTokenResponse>?) -> Void) {
+        authProvider.request(.getUpdatedToken) { [self] (result) in
+            switch result {
+            case .success(let response):
+                do {
+                    self.getUpdatedTokenData = try response.map(GeneralResponse<GetUpdatedTokenResponse>.self)
+                    completion(getUpdatedTokenData)
+                } catch let error {
+                    print(error.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
 }

--- a/Peekabook/Peekabook/Network/DTO/Auth/GetUpdatedTokenResponse.swift
+++ b/Peekabook/Peekabook/Network/DTO/Auth/GetUpdatedTokenResponse.swift
@@ -1,0 +1,12 @@
+//
+//  UpdateTokenRequest.swift
+//  Peekabook
+//
+//  Created by 김인영 on 2023/05/05.
+//
+
+import Foundation
+
+struct GetUpdatedTokenResponse: Codable {
+    let newAccessToken, refreshToken: String
+}

--- a/Peekabook/Peekabook/Network/DTO/Auth/SocialLoginResponse.swift
+++ b/Peekabook/Peekabook/Network/DTO/Auth/SocialLoginResponse.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct SocialLoginResponse: Codable {
     let accessToken, refreshToken: String
+    let isSignedUp: Bool
 }

--- a/Peekabook/Peekabook/Network/Foundation/NetworkConstant.swift
+++ b/Peekabook/Peekabook/Network/Foundation/NetworkConstant.swift
@@ -19,9 +19,9 @@ struct NetworkConstant {
                                     "accessToken": Config.socialToken] as [String: String]
     
     static let hasTokenHeader = ["Content-Type": "application/json",
-                                 "accessToken": Config.accessToken] as [String: String]
+                                 "accessToken": UserDefaults.standard.string(forKey: "accessToken")!] as [String: String]
     
     static let multipartWithTokenHeader = ["Content-Type": "multipart/form-data",
-                                           "accessToken": Config.accessToken] as [String: String]
+                                           "accessToken": UserDefaults.standard.string(forKey: "accessToken")!] as [String: String]
     
 }

--- a/Peekabook/Peekabook/Network/Foundation/NetworkConstant.swift
+++ b/Peekabook/Peekabook/Network/Foundation/NetworkConstant.swift
@@ -19,9 +19,12 @@ struct NetworkConstant {
                                     "accessToken": Config.socialToken] as [String: String]
     
     static let hasTokenHeader = ["Content-Type": "application/json",
-                                 "accessToken": UserDefaults.standard.string(forKey: "accessToken")!] as [String: String]
+                                 "accessToken": UserDefaults.standard.string(forKey: "accessToken") ?? ""] as [String: String]
     
     static let multipartWithTokenHeader = ["Content-Type": "multipart/form-data",
-                                           "accessToken": UserDefaults.standard.string(forKey: "accessToken")!] as [String: String]
+                                           "accessToken": UserDefaults.standard.string(forKey: "accessToken") ?? ""] as [String: String]
     
+    static let updateTokenHeader = ["Content-Type": "application/json",
+                                    "accessToken": UserDefaults.standard.string(forKey: "accessToken") ?? "",
+                                    "refreshToken": UserDefaults.standard.string(forKey: "refreshToken") ?? ""] as [String: String]
 }

--- a/Peekabook/Peekabook/Network/Foundation/UserDefaultsKey.swift
+++ b/Peekabook/Peekabook/Network/Foundation/UserDefaultsKey.swift
@@ -10,8 +10,7 @@ import Foundation
 struct UserDefaultsKey {
     
     // MARK: - Token
-    
-    static let loginComplete: Bool = false
+
     static let accessToken = "accessToken"
     static let refreshToken = "refreshToken"
     

--- a/Peekabook/Peekabook/Network/Foundation/UserManager.swift
+++ b/Peekabook/Peekabook/Network/Foundation/UserManager.swift
@@ -10,9 +10,9 @@ import Foundation
 final class UserManager {
     static let shared = UserManager()
     
-    var userName: String?
+    var userName: String = ""
+    var userIntro: String = ""
     
-    var isLoggedIn: Bool = false
     var imageURL: String?
     
     private init() { }

--- a/Peekabook/Peekabook/Network/Router/AuthRouter.swift
+++ b/Peekabook/Peekabook/Network/Router/AuthRouter.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum AuthRouter {
     case socialLogin(param: SocialLoginRequest)
+    case getUpdatedToken
 }
 
 extension AuthRouter: TargetType {
@@ -22,6 +23,8 @@ extension AuthRouter: TargetType {
         switch self {
         case .socialLogin:
             return URLConstant.auth + "/signin"
+        case .getUpdatedToken:
+            return URLConstant.auth + "/token"
         }
     }
     
@@ -29,6 +32,8 @@ extension AuthRouter: TargetType {
         switch self {
         case .socialLogin:
             return .post
+        case .getUpdatedToken:
+            return .get
         }
     }
     
@@ -36,10 +41,17 @@ extension AuthRouter: TargetType {
         switch self {
         case .socialLogin(let param):
             return .requestJSONEncodable(param)
+        case .getUpdatedToken:
+            return .requestPlain
         }
     }
     
     var headers: [String: String]? {
-        return NetworkConstant.socialTokenHeader
+        switch self {
+        case .socialLogin:
+            return NetworkConstant.socialTokenHeader
+        case .getUpdatedToken:
+            return NetworkConstant.updateTokenHeader
+        }
     }
 }

--- a/Peekabook/Peekabook/Presentation/Auth/VC/LoginVC.swift
+++ b/Peekabook/Peekabook/Presentation/Auth/VC/LoginVC.swift
@@ -317,9 +317,13 @@ extension LoginVC {
             if response?.success == true {
                 if let data = response?.data {
                     Config.accessToken = data.accessToken
+                    Config.isSignedUp = data.isSignedUp
+                    print("Config의 isSignedUp", Config.isSignedUp)
 
-                    UserDefaults.standard.setValue(data.accessToken, forKey: "accessToken")
-                    UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
+                    // UserDefaults
+//                    UserDefaults.standard.setValue(data.accessToken, forKey: "accessToken")
+//                    UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
+                    print("UserDefaults의 isSignedUp", UserDefaults.standard.bool(forKey: "signedUpComplete"))
                 }
             }
         }

--- a/Peekabook/Peekabook/Presentation/Auth/VC/LoginVC.swift
+++ b/Peekabook/Peekabook/Presentation/Auth/VC/LoginVC.swift
@@ -321,9 +321,17 @@ extension LoginVC {
                     print("Config의 isSignedUp", Config.isSignedUp)
 
                     // UserDefaults
-//                    UserDefaults.standard.setValue(data.accessToken, forKey: "accessToken")
-//                    UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
-                    print("UserDefaults의 isSignedUp", UserDefaults.standard.bool(forKey: "signedUpComplete"))
+                    UserDefaults.standard.setValue(data.accessToken, forKey: "accessToken")
+                    UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
+                    UserDefaults.standard.set(data.isSignedUp, forKey: "isSignedUpComplete")
+                    if let token = UserDefaults.standard.string(forKey: "accessToken") {
+                        print("🕺🕺 Login VC --------> Access Token : ", token)
+                    }
+                    print("UserDefaults의 isSignedUp", UserDefaults.standard.bool(forKey: "isSignedUpComplete"))
+                    
+                    if data.isSignedUp {
+                        self.switchRootViewController(rootViewController: TabBarController(), animated: true, completion: nil)
+                    }
                 }
             }
         }

--- a/Peekabook/Peekabook/Presentation/Auth/VC/SignUpVC.swift
+++ b/Peekabook/Peekabook/Presentation/Auth/VC/SignUpVC.swift
@@ -453,9 +453,14 @@ extension SignUpVC {
             if response?.success == true {
                 self.switchRootViewController(rootViewController: TabBarController(), animated: true, completion: nil)
                 
+                // UserDefaults
                 UserDefaults.standard.setValue(self.nicknameText, forKey: "userNickname")
                 UserDefaults.standard.setValue(self.introText, forKey: "userIntro")
-                UserDefaults.standard.setValue(true, forKey: "loginComplete")
+                UserDefaults.standard.setValue(true, forKey: "signedUpComplete")
+
+                UserManager.shared.userName = self.nicknameText
+                UserManager.shared.userIntro = self.introText
+                Config.isSignedUp = true
             }
         }
     }

--- a/Peekabook/Peekabook/Presentation/Auth/VC/SignUpVC.swift
+++ b/Peekabook/Peekabook/Presentation/Auth/VC/SignUpVC.swift
@@ -456,11 +456,10 @@ extension SignUpVC {
                 // UserDefaults
                 UserDefaults.standard.setValue(self.nicknameText, forKey: "userNickname")
                 UserDefaults.standard.setValue(self.introText, forKey: "userIntro")
-                UserDefaults.standard.setValue(true, forKey: "signedUpComplete")
+                UserDefaults.standard.set(true, forKey: "isSignedUpComplete")
 
                 UserManager.shared.userName = self.nicknameText
                 UserManager.shared.userIntro = self.introText
-                Config.isSignedUp = true
             }
         }
     }

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -616,7 +616,7 @@ extension BookShelfVC {
             self.pickCollectionView.reloadData()
         }
     }
-    
+
     private func getFriendBookShelfInfo(userId: Int) {
         BookShelfAPI.shared.getFriendBookShelfInfo(friendId: userId) { response in
             self.serverFriendBookShelfInfo = response?.data

--- a/Peekabook/Peekabook/Presentation/MyPage/VC/DeleteAccountPopUpVC.swift
+++ b/Peekabook/Peekabook/Presentation/MyPage/VC/DeleteAccountPopUpVC.swift
@@ -61,8 +61,8 @@ extension DeleteAccountPopUpVC {
         MyPageAPI.shared.deleteAccount { response in
             if response?.success == true {
                 self.switchRootViewController(rootViewController: LoginVC(), animated: true, completion: nil)
-                Config.accessToken = ""
-                Config.socialToken = ""
+                UserDefaults.standard.removeObject(forKey: "accessToken")
+                UserDefaults.standard.removeObject(forKey: "refreshToken")
             }
         }
     }


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#231

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
UserDefaults를 이용해 자동로그인 로직 수정 및 구현 완료
토큰재발급 API 연결

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
[이슈상황]
- 토큰 재발급: acccessToken과 refreshToken이 **동시에 만료**됨
- 만료되었을 때 **loginVC로 이동**, 그 후 카카오로그인 버튼 누르면 계속 "모든 토큰이 만료되었습니다. 재로그인 해주세요."라고 뜨고 화면이 넘어가지 않음.
- LoginVC의 카카오 로그인 메서드 속 UserDefaults에 담긴 accessToken값이 print되지 않음 (만료 후 LoginVC에 처음 진입했을 때 print문이 찍히지만 그 이후로는 찍히지 않음)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #231
