### PR TITLE
[Fix] #270 - 탭 바 두 번 터치 시 맨위로 스크롤

### DIFF
--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -566,6 +566,7 @@ extension BookShelfVC {
         } else {
             print("바텀시트가 이미 내려가있슴니다")
         }
+        selectedUserIndex = nil
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -560,13 +560,11 @@ extension BookShelfVC {
     }
     
     func scrollToTop() {
-        let bottomShelfVC = bottomShelfVC
         if bottomShelfVC.checkBottomShelfUp(y: bottomShelfVC.view.frame.minY) == true {
             print("바텀시트가 올라가있어서 내릴게요")
         } else {
             print("바텀시트가 이미 내려가있슴니다")
         }
-        
         let contentOffset = CGPoint(x: 0, y: 0)
         pickCollectionView.setContentOffset(contentOffset, animated: true)
     }

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -566,7 +566,6 @@ extension BookShelfVC {
         } else {
             print("바텀시트가 이미 내려가있슴니다")
         }
-        selectedUserIndex = nil
         
         let contentOffset = CGPoint(x: 0, y: 0)
         pickCollectionView.setContentOffset(contentOffset, animated: true)

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -560,7 +560,12 @@ extension BookShelfVC {
     }
     
     func scrollToTop() {
-        print("hi I am tapped~ wahaha")
+        let bottomShelfVC = bottomShelfVC
+        if bottomShelfVC.checkBottomShelfUp(y: bottomShelfVC.view.frame.minY) == true {
+            print("바텀시트가 올라가있어서 내릴게요")
+        } else {
+            print("바텀시트가 이미 내려가있슴니다")
+        }
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -558,6 +558,10 @@ extension BookShelfVC {
             }
         }
     }
+    
+    func scrollToTop() {
+        print("hi I am tapped~ wahaha")
+    }
 }
 
 // MARK: - UICollectionViewDelegate, UICollectionViewDataSource

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BookShelfVC.swift
@@ -567,6 +567,9 @@ extension BookShelfVC {
             print("바텀시트가 이미 내려가있슴니다")
         }
         selectedUserIndex = nil
+        
+        let contentOffset = CGPoint(x: 0, y: 0)
+        pickCollectionView.setContentOffset(contentOffset, animated: true)
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BottomBookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BottomBookShelfVC.swift
@@ -333,4 +333,24 @@ extension BottomBookShelfVC: UIGestureRecognizerDelegate {
         }
         return false
     }
+    
+    func checkBottomShelfUp(y: CGFloat) -> Bool {
+        UIView.animateWithDamping(animation: {
+            if Int(y) == Int(self.fullView) {
+                self.view.frame = CGRect(x: 0, y: self.partialView, width: self.view.frame.width, height: self.view.frame.height)
+            } else {
+                print("이미 내려가있어서요")
+            }
+        }, completion: nil)
+        
+        if Int(y) == Int(fullView) {
+            // BottomShelf가 위로 올라가있는 경우
+            return true
+        } else if Int(y) == Int(partialView) {
+            // BottomShelf가 아래에 내려가있는 경우
+            print("이미 내려가있음요")
+            return false
+        }
+        return false
+    }
 }

--- a/Peekabook/Peekabook/Presentation/BookShelf/VC/BottomBookShelfVC.swift
+++ b/Peekabook/Peekabook/Presentation/BookShelf/VC/BottomBookShelfVC.swift
@@ -338,18 +338,11 @@ extension BottomBookShelfVC: UIGestureRecognizerDelegate {
         UIView.animateWithDamping(animation: {
             if Int(y) == Int(self.fullView) {
                 self.view.frame = CGRect(x: 0, y: self.partialView, width: self.view.frame.width, height: self.view.frame.height)
-            } else {
-                print("이미 내려가있어서요")
             }
         }, completion: nil)
         
         if Int(y) == Int(fullView) {
-            // BottomShelf가 위로 올라가있는 경우
             return true
-        } else if Int(y) == Int(partialView) {
-            // BottomShelf가 아래에 내려가있는 경우
-            print("이미 내려가있음요")
-            return false
         }
         return false
     }

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendVC.swift
@@ -154,7 +154,7 @@ extension RecommendVC {
         )
     }
     
-    private func setFirstIndexSelected() {
+    func setFirstIndexSelected() {
         let selectedIndexPath = IndexPath(item: 0, section: 0)
         recommendCollectionView.selectItem(
             at: selectedIndexPath,
@@ -171,8 +171,10 @@ extension RecommendVC {
     }
     
     func scrollToTop() {
-        setFirstIndexSelected()
         if let currentViewController = pageViewController.viewControllers?.first as? RecommendedVC {
+            currentViewController.scrollToTop()
+        }
+        if let currentViewController = pageViewController.viewControllers?.first as? RecommendingVC {
             currentViewController.scrollToTop()
         }
     }
@@ -203,6 +205,7 @@ extension RecommendVC: UICollectionViewDelegate, UICollectionViewDataSource, UIC
             animated: true,
             completion: nil
         )
+        self.scrollToTop()
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendVC.swift
@@ -154,7 +154,7 @@ extension RecommendVC {
         )
     }
     
-    func setFirstIndexSelected() {
+    private func setFirstIndexSelected() {
         let selectedIndexPath = IndexPath(item: 0, section: 0)
         recommendCollectionView.selectItem(
             at: selectedIndexPath,

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendVC.swift
@@ -169,6 +169,13 @@ extension RecommendVC {
             completion: nil
         )
     }
+    
+    func scrollToTop() {
+        setFirstIndexSelected()
+        if let currentViewController = pageViewController.viewControllers?.first as? RecommendedVC {
+            currentViewController.scrollToTop()
+        }
+    }
 }
 
 // MARK: - UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendedVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendedVC.swift
@@ -91,8 +91,8 @@ extension RecommendedVC {
     }
     
     func scrollToTop() {
-        let indexPath = IndexPath(row: 0, section: 0)
-        recommendedTableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        let contentOffset = CGPoint(x: 0, y: 0)
+        self.recommendedTableView.setContentOffset(contentOffset, animated: true)
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendedVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendedVC.swift
@@ -89,6 +89,11 @@ extension RecommendedVC {
         recommendedTableView.delegate = self
         recommendedTableView.dataSource = self
     }
+    
+    func scrollToTop() {
+        let indexPath = IndexPath(row: 0, section: 0)
+        recommendedTableView.scrollToRow(at: indexPath, at: .top, animated: true)
+    }
 }
 
 extension RecommendedVC: UITableViewDelegate, UITableViewDataSource {

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
@@ -90,9 +90,9 @@ extension RecommendingVC {
         recommendingTableView.dataSource = self
     }
     
-    private func scrollToTop() {
+    func scrollToTop() {
         let indexPath = IndexPath(row: 0, section: 0)
-        recommendingTableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        self.recommendingTableView.scrollToRow(at: indexPath, at: .top, animated: true)
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
@@ -91,8 +91,8 @@ extension RecommendingVC {
     }
     
     func scrollToTop() {
-        let indexPath = IndexPath(row: 0, section: 0)
-        self.recommendingTableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        let contentOffset = CGPoint(x: 0, y: 0)
+        self.recommendingTableView.setContentOffset(contentOffset, animated: true)
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
@@ -85,9 +85,14 @@ extension RecommendingVC {
         )
     }
     
-    private func setDelegate() {
+    func setDelegate() {
         recommendingTableView.delegate = self
         recommendingTableView.dataSource = self
+    }
+    
+    private func scrollToTop() {
+        let indexPath = IndexPath(row: 0, section: 0)
+        recommendingTableView.scrollToRow(at: indexPath, at: .top, animated: true)
     }
 }
 

--- a/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
+++ b/Peekabook/Peekabook/Presentation/Recommend/VC/RecommendingVC.swift
@@ -85,7 +85,7 @@ extension RecommendingVC {
         )
     }
     
-    func setDelegate() {
+    private func setDelegate() {
         recommendingTableView.delegate = self
         recommendingTableView.dataSource = self
     }

--- a/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
+++ b/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
@@ -12,6 +12,7 @@ final class TabBarController: UITabBarController {
     
     // MARK: - Properties
     private var refreshLaunch = true
+    private var lastSelectedIndex: Int = -1
     
     // MARK: - View Life Cycle
     
@@ -25,9 +26,8 @@ final class TabBarController: UITabBarController {
     // MARK: - Custom Methods
     
     private func setViewControllers() {
-        
+
         let bookShelfNVC = makeNavigationController(
-            
             unselectedImage: ImageLiterals.TabBar.bookshelf,
             selectedImage: ImageLiterals.TabBar.bookshelfSelected,
             rootViewController: BookShelfVC(), title: I18N.Tabbar.bookshelf)
@@ -49,6 +49,8 @@ final class TabBarController: UITabBarController {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .peekaRed
         tabBar.unselectedItemTintColor = .peekaGray1
+        
+        self.delegate = self
     }
     
     private func makeNavigationController(unselectedImage: UIImage?, selectedImage: UIImage?, rootViewController: UIViewController, title: String) -> UINavigationController {
@@ -68,6 +70,7 @@ final class TabBarController: UITabBarController {
         
         nav.interactivePopGestureRecognizer?.isEnabled = true
         nav.interactivePopGestureRecognizer?.delegate = self
+        
         return nav
     }
     
@@ -91,3 +94,16 @@ final class TabBarController: UITabBarController {
 }
 
 extension TabBarController: UIGestureRecognizerDelegate { }
+
+extension TabBarController: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        if lastSelectedIndex == selectedIndex {
+            if let bookShelfVC = viewController.children.first(where: { $0 is BookShelfVC }) as? BookShelfVC {
+                bookShelfVC.scrollToTop()
+            }
+        }
+        
+        lastSelectedIndex = selectedIndex
+        print(lastSelectedIndex)
+    }
+}

--- a/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
+++ b/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
@@ -12,7 +12,7 @@ final class TabBarController: UITabBarController {
     
     // MARK: - Properties
     private var refreshLaunch = true
-    private var lastSelectedIndex: Int = -1
+    private var lastSelectedIndex: Int?
     
     // MARK: - View Life Cycle
     
@@ -102,7 +102,6 @@ extension TabBarController: UITabBarControllerDelegate {
                 bookShelfVC.scrollToTop()
             }
             if let recommendVC = viewController.children.first(where: { $0 is RecommendVC }) as? RecommendVC {
-                recommendVC.setFirstIndexSelected()
                 recommendVC.scrollToTop()
             }
         }

--- a/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
+++ b/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
@@ -104,6 +104,5 @@ extension TabBarController: UITabBarControllerDelegate {
         }
         
         lastSelectedIndex = selectedIndex
-        print(lastSelectedIndex)
     }
 }

--- a/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
+++ b/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
@@ -102,6 +102,7 @@ extension TabBarController: UITabBarControllerDelegate {
                 bookShelfVC.scrollToTop()
             }
             if let recommendVC = viewController.children.first(where: { $0 is RecommendVC }) as? RecommendVC {
+                recommendVC.setFirstIndexSelected()
                 recommendVC.scrollToTop()
             }
         }

--- a/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
+++ b/Peekabook/Peekabook/Presentation/TabBar/TabBarController.swift
@@ -101,6 +101,9 @@ extension TabBarController: UITabBarControllerDelegate {
             if let bookShelfVC = viewController.children.first(where: { $0 is BookShelfVC }) as? BookShelfVC {
                 bookShelfVC.scrollToTop()
             }
+            if let recommendVC = viewController.children.first(where: { $0 is RecommendVC }) as? RecommendVC {
+                recommendVC.scrollToTop()
+            }
         }
         
         lastSelectedIndex = selectedIndex


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#270

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
탭바 두 번 클릭 시 스크롤은 맨 위로, 올라와있는 바텀 뷰는 다시 내리는 작업을 하였습니다.
1. **책장 뷰**
 - 친구 책장을 보고있던 경우  ➡️  친구 책장의 맨 위로 (추가수정)
 - PickView는 제일 처음으로 (맨 왼쪽으로 스크롤)
 - 바텀뷰(전체 책 조회, BottomBookShelf)의 경우 올라와있으면 다시 원래대로 내림

2. **추천 뷰**
 - 메뉴 셀 (추천받은 책, 추천한 책)을 누른 경우  ➡️  해당 뷰의 제일 상단으로 스크롤

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
스크린샷에서 이해가 안되는 부분이 있다면 말씀해주세요!

## 📸 스크린샷
### 1. 책장
https://github.com/team-peekabook/Peekabook-iOS/assets/83493636/2d3c00b2-7005-4c19-862f-ffffb12e0eaa

### 2. 추천
https://github.com/team-peekabook/Peekabook-iOS/assets/83493636/56db2b28-2ea5-4cca-b18f-0750286885f3


## 📟 관련 이슈
- Resolved: #270 
